### PR TITLE
[STLT-19] ✨ (CircleCI Release Pipeline) Add `deploy-release` step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,27 @@ commands:
             # Generate protobufs
             make protobuf
 
+  configure-build-env:
+    steps:
+      - update-submodules
+      - pre-cache
+      - restore-from-cache
+      - pre-make
+
+      - save_cache:
+          name: Save make to cache
+          key: v13_make.bin-{{ checksum "~/make.md5" }}
+          paths:
+            - make.bin
+
+      - save_cache:
+          name: Save dot to cache
+          key: v13_dot.bin-{{ checksum "~/dot.md5" }}
+          paths:
+            - dot.bin
+
+      - make-init
+
 workflows:
   circleci:
     jobs:
@@ -208,6 +229,15 @@ workflows:
               only: /^([0-9]+\.){3}dev[0-9]+/
             branches:
               ignore: /.*/
+      - build-deploy-rc:
+          requires:
+            - python-min-version
+            - python-max-version
+            - cypress
+          filters:
+            branches:
+              only: /^release\/([0-9]+\.){2}([0-9]+)/
+
       # Uncomment to get a button that runs flaky tests on CircleCI:
       # - cypress-flaky-approval:
       #     type: approval
@@ -230,15 +260,9 @@ workflows:
                 - develop
     jobs:
       - create-tag
-  release-pipeline:
-    jobs:
-      - create-release:
-          filters:
-            branches:
-              only: /^release\/([0-9]+\.){2}([0-9]+)/
 
 jobs:
-  create-release:
+  build-deploy-rc:
     resource_class: large
     docker:
       - image: circleci/python:3.9.7
@@ -246,9 +270,15 @@ jobs:
     steps:
       - checkout:
           name: Checkout Streamlit code
+
+      - configure-build-env
+
       - run:
-          name: Set version from branch name
-          command: echo 'export STREAMLIT_RELEASE_VERSION=$(echo $CIRCLE_BRANCH | tr -d "release/")' >> $BASH_ENV
+          name: Set desired version from branch name
+          command: echo 'export DESIRED_VERSION=$(echo $CIRCLE_BRANCH | tr -d "release/")' >> $BASH_ENV
+      - run:
+          name: Set final version with pre-release
+          command: echo 'export STREAMLIT_RELEASE_VERSION=$(python scripts/get_prerelease_version.py $DESIRED_VERSION)' >> $BASH_ENV
       - run:
           name: Update streamlit version
           command: |
@@ -261,36 +291,43 @@ jobs:
             git config user.name "Streamlit Bot"
 
             git commit -am "Up version to $STREAMLIT_RELEASE_VERSION [skip ci]" && git push origin $CIRCLE_BRANCH || echo "No changes to commit"
-      - update-submodules
-      - pre-cache
-      - restore-from-cache
-      - pre-make
 
-      - save_cache:
-          name: Save make to cache
-          key: v13_make.bin-{{ checksum "~/make.md5" }}
-          paths:
-            - make.bin
-
-      - save_cache:
-          name: Save dot to cache
-          key: v13_dot.bin-{{ checksum "~/dot.md5" }}
-          paths:
-            - dot.bin
-
-      - make-init
+      # Password added to circleci environment
+      # https://ui.circleci.com/settings/project/github/streamlit/streamlit/environment-variables
+      - run:
+          name: init .pypirc
+          command: |
+            cd lib
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = streamlit" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
 
       - run:
           name: Make package
-          no_output_timeout: 30m
+          no_output_timeout: 2h
           command: |
             echo "working directory = $(pwd)"
             chmod +x ./frontend/scripts/preload-bokeh.sh
             ${SUDO} apt-get install rsync
             make package
 
+      # TODO: need to fix this - it doesn't seem to run with the correct build/version
+      # - run:
+      #     name: Run CLI regression tests with full build
+      #     command: |
+      #       make cli-regression-tests
+
       - store_artifacts:
           path: ./lib/dist
+
+      - run:
+          name: upload to pypi
+          command: |
+            make distribute
+
+      - slack/status:
+          success_message: ":rocket: RC version ${STREAMLIT_RELEASE_VERSION} was successful!"
+          failure_message: ":blobonfire: RC version ${STREAMLIT_RELEASE_VERSION} failed to release"
 
   python-max-version: &job-template
     docker:

--- a/lib/Pipfile
+++ b/lib/Pipfile
@@ -65,3 +65,4 @@ validators = "*"
 watchdog = {version = "*", markers = "platform_system != 'Darwin'"}
 gitpython = "!=3.1.19"
 typing-extensions = { version = "*", markers = "python_version < '3.8'" }
+semver = "*"

--- a/lib/mypy.ini
+++ b/lib/mypy.ini
@@ -44,3 +44,6 @@ ignore_missing_imports = True
 
 [mypy-altair.*,base58,blinker,bokeh.embed,botocore,boto3,cachetools.*,chart_studio.*,cPickle,flake8.main,future.*,matplotlib,matplotlib.pyplot,numpy,pandas.*,PIL,pipenv.*,plotly.*,prometheus_client,pyarrow,pydeck,pyflakes,pyflakes.checker,setuptools.*,sympy,tensorflow.*,tzlocal,validators,watchdog,watchdog.observers]
 ignore_missing_imports = true
+
+[mypy-semver.*]
+ignore_missing_imports = True

--- a/scripts/get_prerelease_version.py
+++ b/scripts/get_prerelease_version.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# Copyright 2022 Streamlit Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calculate the next appropriate pre-release based on the target version.
+
+- If the current version is the same as the target version, increment the pre-release only
+- If the current version is less than the target version, first update the version to match, then
+increment the pre-release version
+
+A few examples:
+
+- Target: 1.6.0
+  Current: 1.5.1
+  Output: 1.6.0-rc1
+
+- Target: 1.6.0
+  Current:1.6.0-rc1
+  Output: 1.6.0-rc2
+
+"""
+
+import fileinput
+import os
+import re
+import sys
+
+import semver
+
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def get_current_version():
+    """Retrieve the current version by searching for a matching regex ('VERSION=') in setup.py"""
+    filename = os.path.join(BASE_DIR, "lib/setup.py")
+    regex = r"(?P<pre>.*VERSION = \")(.*)(?P<post>\"  # PEP-440$)"
+    pattern = re.compile(regex)
+
+    for line in fileinput.input(filename):
+        match = pattern.match(line.rstrip())
+        if match:
+            return match.groups()[1]
+
+    raise Exception('Did not find regex "%s" for version in setup.py' % (regex))
+
+
+def main():
+    if len(sys.argv) != 2:
+        raise Exception(
+            'Specify target version as an argument: "%s 1.2.3"' % sys.argv[0]
+        )
+
+    target_version = semver.VersionInfo.parse(sys.argv[1])
+    current_version = semver.VersionInfo.parse(get_current_version())
+
+    if current_version.finalize_version() < target_version:
+        current_version = target_version
+
+    print(str(current_version.bump_prerelease()))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📚 Context

_Please describe the project or issue background here_

- What kind of change does this PR introduce?

  - [X] Other, please describe: Add RC build/deploy pipeline

## 🧠 Description of Changes

  - Add `get_prerelease_version` script to calculate the appropriate version
  - Move configuration of build environment to the `configure-build-env` command (update submods, install and cache deps, initialize)
  - Move rc job into the main circleci workflow - this allows us to only build the rc if the required checks pass (e.g. python min/max versions and cypress)
  - Infer the correct pre-release version based on the current branch name
  - Configure and upload to PyPI. PyPI automatically marks the release as a pre-release based on the version
  - Increase timeout for build to match nightly

## 🧪 Testing Done

- [X] Tested in Cuttlesoft's fork to test the pre-release version calculation, version upgrades, build, and artifact upload. Did not test: PyPI config and upload, Slack notification

## 🌐 References

N/A
